### PR TITLE
Helps better error surface

### DIFF
--- a/lib/resort.rb
+++ b/lib/resort.rb
@@ -94,7 +94,7 @@ module Resort
         elements = {}
 
         all.each do |element|
-          if ordered_elements.empty? && element.first?
+          if element.first?
             ordered_elements << element
           else
             elements[element.id] = element


### PR DESCRIPTION
By removing this check, the better error will raise if more than one item is found to be first.
