### PR TITLE
Updated the Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -139,10 +139,10 @@ class Product < ActiveRecord::Base
   end
 end
 
-bread = Product.create(:name => 'Bread', :vendor => Vendor.where(:name => 'Bread factory'))
+bread = Product.create(:name => 'Bread', :vendor => Vendor.where(:name => 'Bread factory').first)
 bread.first? # => true
 
-milk = Product.create(:name => 'Milk', :vendor => Vendor.where(:name => 'Cow world'))
+milk = Product.create(:name => 'Milk', :vendor => Vendor.where(:name => 'Cow world').first)
 milk.first? # => true
 
 # bread and milk aren't neighbours


### PR DESCRIPTION
In readme there is an example like this:

`bread = Product.create(:name => 'Bread', :vendor => Vendor.where(:name => 'Bread factory'))`

But `Vendor.where(:name => 'Bread factory'))` returns `Vendor::ActiveRecord_Relation` but not a `Vendor` record.

So, I've updated the Readme and created this PR.